### PR TITLE
feat: Add analyzer to detect and report unused result expressions

### DIFF
--- a/lint/unused_result_analyzer.go
+++ b/lint/unused_result_analyzer.go
@@ -1,0 +1,86 @@
+/*
+ * Cadence-lint - The Cadence linter
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lint
+
+import (
+	"fmt"
+
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/tools/analysis"
+)
+
+func getDiagnostic(location common.Location, element ast.Element, op string) analysis.Diagnostic {
+	return analysis.Diagnostic{
+		Location: location,
+		Range:    ast.NewRangeFromPositioned(nil, element),
+		Category: UpdateCategory,
+		Message:  "Unused result of " + op + ".",
+	}
+}
+
+var UnusedResultAnalyzer = (func() *analysis.Analyzer {
+
+	elementFilter := []ast.Element{
+		(*ast.ExpressionStatement)(nil),
+	}
+	return &analysis.Analyzer{
+		Description: "Detects expressions with unused results.",
+		Requires: []*analysis.Analyzer{
+			analysis.InspectorAnalyzer,
+		},
+		Run: func(pass *analysis.Pass) interface{} {
+			inspector := pass.ResultOf[analysis.InspectorAnalyzer].(*ast.Inspector)
+
+			location := pass.Program.Location
+			report := pass.Report
+
+			inspector.Preorder(
+				elementFilter,
+				func(element ast.Element) {
+					expressionStatement, ok := element.(*ast.ExpressionStatement)
+					if !ok {
+						return
+					}
+
+					switch fmt.Sprint(expressionStatement.Expression.ElementType()) {
+					case "ElementTypeUnaryExpression":
+						report(getDiagnostic(location, element, "Unary operation"))
+					case "ElementTypeBinaryExpression":
+						report(getDiagnostic(location, element, "Binary operation"))
+					case "ElementTypeInvocationExpression":
+						// TODO: check function invocation
+						fmt.Println(expressionStatement, "ElementTypeInvocationExpression")
+						return
+					default:
+						return
+					}
+				},
+			)
+			return nil
+		},
+	}
+})()
+
+func init() {
+	RegisterAnalyzer(
+		"unused-result",
+		UnusedResultAnalyzer,
+	)
+}

--- a/lint/unused_result_analyzer_test.go
+++ b/lint/unused_result_analyzer_test.go
@@ -1,0 +1,130 @@
+/*
+ * Cadence-lint - The Cadence linter
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lint_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/tools/analysis"
+
+	"github.com/onflow/cadence-tools/lint"
+)
+
+func TestUnusedResultAnalyzer(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("unary operation", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+			pub contract Test {
+				pub fun test() {
+					let b = true
+					!b
+				}
+			}
+			`,
+			lint.UnusedResultAnalyzer,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic{
+				{
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 68, Line: 5, Column: 5},
+						EndPos:   ast.Position{Offset: 69, Line: 5, Column: 6},
+					},
+					Location: testLocation,
+					Category: lint.UpdateCategory,
+					Message:  "Unused result of Unary operation.",
+				},
+			},
+			diagnostics,
+		)
+	})
+
+	t.Run("binary operation", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+			pub contract Test {
+				pub fun test() {
+					let a = 10
+					let b = 20
+					a + b
+				}
+			}
+			`,
+			lint.UnusedResultAnalyzer,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic{
+				{
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 82, Line: 6, Column: 5},
+						EndPos:   ast.Position{Offset: 86, Line: 6, Column: 9},
+					},
+					Location: testLocation,
+					Category: lint.UpdateCategory,
+					Message:  "Unused result of Binary operation.",
+				},
+			},
+			diagnostics,
+		)
+	})
+
+	// TODO: test function invocation
+
+	t.Run("valid", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+			pub contract Test {
+				pub fun test() {
+					let a = 10
+					let b = 20
+					let c = a + b
+					var d = true
+					d = !d
+				}
+			}
+			`,
+			lint.UnusedResultAnalyzer,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic(nil),
+			diagnostics,
+		)
+	})
+}


### PR DESCRIPTION
Closes #9

## Description

Created `UnusedResultAnalyzer` which detects and reports Unary, Binary operations (todo: function invocation) with unused results.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
